### PR TITLE
Analyze Claude Code plugins and improve kit

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,17 +1,82 @@
 {
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "claude-code-kit",
-  "description": "A curated collection of framework-specific plugins for Claude Code with automatic detection",
   "version": "1.0.0",
+  "description": "Framework-specific plugins for Claude Code with automatic detection and installation",
+  "owner": {
+    "name": "blencorp",
+    "email": "support@blencorp.com"
+  },
   "plugins": [
-    "nextjs",
-    "react",
-    "express",
-    "nodejs",
-    "prisma",
-    "tailwindcss",
-    "shadcn",
-    "mui",
-    "tanstack-query",
-    "tanstack-router"
+    {
+      "name": "nextjs",
+      "description": "Next.js 15+ App Router, Server Components, Server Actions",
+      "source": "./cli/kits/nextjs",
+      "category": "development",
+      "version": "1.0.0"
+    },
+    {
+      "name": "react",
+      "description": "React 18+ hooks, Suspense, lazy loading, TypeScript patterns",
+      "source": "./cli/kits/react",
+      "category": "development",
+      "version": "1.0.0"
+    },
+    {
+      "name": "express",
+      "description": "Express.js routing, middleware, controllers, error handling",
+      "source": "./cli/kits/express",
+      "category": "development",
+      "version": "1.0.0"
+    },
+    {
+      "name": "nodejs",
+      "description": "Node.js backend patterns with TypeScript and layered architecture",
+      "source": "./cli/kits/nodejs",
+      "category": "development",
+      "version": "1.0.0"
+    },
+    {
+      "name": "prisma",
+      "description": "Prisma ORM patterns for type-safe database access",
+      "source": "./cli/kits/prisma",
+      "category": "development",
+      "version": "1.0.0"
+    },
+    {
+      "name": "tailwindcss",
+      "description": "Tailwind CSS v4 utility patterns and responsive design",
+      "source": "./cli/kits/tailwindcss",
+      "category": "development",
+      "version": "1.0.0"
+    },
+    {
+      "name": "shadcn",
+      "description": "shadcn/ui component library with Radix UI primitives",
+      "source": "./cli/kits/shadcn",
+      "category": "development",
+      "version": "1.0.0"
+    },
+    {
+      "name": "mui",
+      "description": "Material-UI v7 components and sx prop styling",
+      "source": "./cli/kits/mui",
+      "category": "development",
+      "version": "1.0.0"
+    },
+    {
+      "name": "tanstack-query",
+      "description": "TanStack Query v5 data fetching and cache management",
+      "source": "./cli/kits/tanstack-query",
+      "category": "development",
+      "version": "1.0.0"
+    },
+    {
+      "name": "tanstack-router",
+      "description": "TanStack Router file-based routing with type-safe navigation",
+      "source": "./cli/kits/tanstack-router",
+      "category": "development",
+      "version": "1.0.0"
+    }
   ]
 }

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "claude-code-kit",
+  "description": "A curated collection of framework-specific plugins for Claude Code with automatic detection",
+  "version": "1.0.0",
+  "plugins": [
+    "nextjs",
+    "react",
+    "express",
+    "nodejs",
+    "prisma",
+    "tailwindcss",
+    "shadcn",
+    "mui",
+    "tanstack-query",
+    "tanstack-router"
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -3,7 +3,8 @@
   "description": "Framework detection and plugin installer for Claude Code. Detects your project's tech stack (Next.js, React, Express, Prisma, etc.) and installs the appropriate plugins automatically.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   },
   "repository": "https://github.com/blencorp/claude-code-kit"
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "claude-code-kit",
+  "description": "Framework detection and plugin installer for Claude Code. Detects your project's tech stack (Next.js, React, Express, Prisma, etc.) and installs the appropriate plugins automatically.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  },
+  "repository": "https://github.com/blencorp/claude-code-kit"
+}

--- a/README.md
+++ b/README.md
@@ -11,33 +11,28 @@ Get expert-level Claude Code assistance for your tech stack in seconds.
 ## Quick Start (Plugin Installation)
 
 ```bash
-# In Claude Code, run:
+# In Claude Code, add the marketplace and run setup:
 /plugin marketplace add blencorp/claude-code-kit
-
-# Install the kit to get the /setup command
-/plugin install claude-code-kit
-
-# Auto-detect your frameworks and get install recommendations
 /setup
 ```
 
-**What happens:**
-1. `/setup` detects your frameworks (Next.js, React, Express, Prisma, etc.)
-2. Shows which plugins match your project
-3. Provides the install command for detected plugins
-4. Skills automatically activate based on conversation context
+**That's it.** `/setup` detects your frameworks and installs the appropriate plugins automatically.
 
-**Example output from `/setup`:**
+**Example:**
 ```
-Detected frameworks in your project:
-  ✓ Next.js 15 (found in package.json)
-  ✓ React 18 (found in package.json)
-  ✓ Prisma (found prisma/schema.prisma)
-  ✓ TailwindCSS (found tailwind.config.ts)
+## Detected Frameworks
 
-To install these plugins:
-  /plugin install nextjs react prisma tailwindcss
+✓ Next.js (found "next" in package.json)
+✓ React (found "react" in package.json)
+✓ Prisma (found prisma/schema.prisma)
+✓ TailwindCSS (found tailwind.config.ts)
+
+## Installing Plugins
+
+Installing: nextjs, react, prisma, tailwindcss
 ```
+
+Skills then activate automatically based on your conversation context.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -4,42 +4,79 @@
 
 # Claude Code Kit
 
-**Claude Code infrastructure with auto-activating skills and framework-specific kits.**
+**A plugin marketplace for Claude Code with framework-specific skills and automatic detection.**
 
-Install complete Claude Code infrastructure in 30 seconds with automatic framework detection and skill auto-activation.
+Get expert-level Claude Code assistance for your tech stack in seconds.
 
-## Quick Start
+## Quick Start (Plugin Installation)
+
+```bash
+# In Claude Code, run:
+/plugin marketplace add blencorp/claude-code-kit
+
+# Install the kit to get the /setup command
+/plugin install claude-code-kit
+
+# Auto-detect your frameworks and get install recommendations
+/setup
+```
+
+**What happens:**
+1. `/setup` detects your frameworks (Next.js, React, Express, Prisma, etc.)
+2. Shows which plugins match your project
+3. Provides the install command for detected plugins
+4. Skills automatically activate based on conversation context
+
+**Example output from `/setup`:**
+```
+Detected frameworks in your project:
+  ✓ Next.js 15 (found in package.json)
+  ✓ React 18 (found in package.json)
+  ✓ Prisma (found prisma/schema.prisma)
+  ✓ TailwindCSS (found tailwind.config.ts)
+
+To install these plugins:
+  /plugin install nextjs react prisma tailwindcss
+```
+
+---
+
+## Alternative: Legacy Installation
+
+For environments without plugin support, use the bash installer:
 
 ```bash
 npx github:blencorp/claude-code-kit
 ```
 
-**What happens:**
-1. Detects your frameworks (Next.js, React, Express, Prisma, etc.)
-2. Asks which kits to install
-3. Copies hooks, agents, commands, and skills to `.claude/`
-4. Configures automatic skill activation via `skill-rules.json`
-5. Installs everything in < 30 seconds
-
-**Result:** Skills automatically activate when you need them based on your prompts, file edits, and technology usage.
+This copies hooks, agents, commands, and skills directly to `.claude/`.
 
 ---
 
-## What's a Kit?
+## What's a Plugin?
 
-A **kit** is a framework-specific package that includes:
-- **Skill** - Best practices, patterns, and examples for the framework
-- **Auto-activation triggers** - Keywords and patterns that activate the skill
-- **Resources** - Detailed guides organized by topic
-- **Detection logic** - Automatic framework detection
+A **plugin** is a framework-specific package following the official Claude Code plugin format:
 
-When installed, kits make Claude Code an expert in your stack.
+```
+plugin-name/
+├── .claude-plugin/
+│   └── plugin.json          # Plugin metadata
+├── skills/
+│   └── framework-name/
+│       ├── SKILL.md         # Best practices and patterns (<500 lines)
+│       └── resources/       # Detailed guides (progressive disclosure)
+├── commands/                # Optional slash commands
+├── agents/                  # Optional specialized agents
+└── hooks/                   # Optional event handlers
+```
+
+Claude automatically loads skills based on their description - no manual trigger configuration needed.
 
 ---
 
-## Available Kits
+## Available Plugins
 
-### Frontend Kits
+### Frontend Plugins
 
 | Kit | Description | Documentation |
 |-----|-------------|---------------|
@@ -51,7 +88,7 @@ When installed, kits make Claude Code an expert in your stack.
 | **TanStack Router** | File-based routing, loaders, type-safe navigation | [README](cli/kits/tanstack-router/README.md) |
 | **TanStack Query** | Data fetching with useSuspenseQuery, cache management | [README](cli/kits/tanstack-query/README.md) |
 
-### Backend Kits
+### Backend Plugins
 
 | Kit | Description | Documentation |
 |-----|-------------|---------------|
@@ -59,7 +96,7 @@ When installed, kits make Claude Code an expert in your stack.
 | **Node.js** | Layered architecture, async patterns, error handling | [README](cli/kits/nodejs/README.md) |
 | **Prisma** | Prisma ORM query patterns, repository pattern, transactions | [README](cli/kits/prisma/README.md) |
 
-**All kits are auto-detected during installation based on your package.json and project structure.**
+**All plugins are auto-detected by `/setup` based on your package.json and project structure.**
 
 ---
 
@@ -109,27 +146,22 @@ Slash commands for common workflows:
 
 ## How It Works
 
-### Auto-Activation System
+### Native Skill Activation
 
-Skills automatically activate based on:
+Claude Code natively loads skills based on their SKILL.md description. When you install a plugin:
 
-1. **Prompt Keywords**
-   - Example: "create a table component" → shadcn skill activates
-   - Example: "query the database" → Prisma skill activates
+1. **Claude reads the skill description** - Each SKILL.md has a `description` field in its YAML frontmatter
+2. **Claude activates contextually** - Based on your conversation, Claude automatically loads relevant skills
+3. **No configuration needed** - Unlike the legacy system, you don't need to manage trigger rules
 
-2. **Intent Patterns** (Regex)
-   - Example: "add.*authentication" → relevant auth patterns activate
-   - Example: "optimize.*component" → React performance skill activates
+**Examples:**
+- Ask "create a server component" → Next.js skill activates
+- Ask "query the database" → Prisma skill activates
+- Ask "add a button with shadcn" → shadcn skill activates
 
-3. **File Path Triggers**
-   - Editing `app/**/*.tsx` → Next.js skill activates
-   - Editing `prisma/schema.prisma` → Prisma skill activates
+### Legacy Auto-Activation (Optional)
 
-4. **Content Patterns**
-   - File contains `useQuery(` → TanStack Query skill activates
-   - File contains `createFileRoute` → TanStack Router skill activates
-
-All configured in `.claude/skills/skill-rules.json` (auto-generated during install).
+The legacy `claude-setup` installer includes a hook-based trigger system with `skill-rules.json` for explicit control over activation. This is optional - Claude's native skill loading handles most cases.
 
 ### What Gets Installed
 
@@ -233,75 +265,86 @@ npx github:blencorp/claude-code-kit
 
 ---
 
-## Contributing Kits
+## Contributing Plugins
 
-Want to add support for a new framework? Here's how to create a kit:
+Want to add support for a new framework? Here's how to create a plugin:
 
-### Kit Structure
+### Plugin Structure
 
 ```
 cli/kits/your-framework/
-├── kit.json                      # Metadata and detection
+├── .claude-plugin/
+│   └── plugin.json              # Plugin metadata (required)
+├── kit.json                     # Detection logic (for /setup)
 ├── skills/
 │   └── your-framework/
 │       ├── SKILL.md             # Main skill file (<500 lines)
-│       ├── skill-rules-fragment.json  # Auto-activation triggers
 │       └── resources/           # Optional: detailed guides
 │           ├── topic-1.md
 │           └── topic-2.md
-└── agents/                      # Optional: kit-specific agents
-    └── your-framework-agent.md
+├── commands/                    # Optional: slash commands
+├── agents/                      # Optional: specialized agents
+└── hooks/                       # Optional: event handlers
 ```
 
-### kit.json Format
+### plugin.json Format
+
+```json
+{
+  "name": "your-framework",
+  "description": "Complete description including keywords Claude uses to activate this skill contextually. Mention key concepts, APIs, and use cases.",
+  "version": "1.0.0",
+  "author": {
+    "name": "your-name"
+  }
+}
+```
+
+### kit.json Format (for /setup detection)
 
 ```json
 {
   "name": "your-framework",
   "displayName": "Your Framework",
-  "description": "Short description of what this kit provides",
-  "detect": "command to detect framework",
-  "provides": ["skill:your-framework"]
+  "description": "Short description",
+  "detect": {
+    "command": "grep -q '\"your-framework\"' package.json"
+  }
 }
 ```
 
 **Detection Examples:**
 ```bash
 # Detect from package.json
-"detect": "grep -q '\"your-framework\"' package.json"
+"command": "grep -q '\"your-framework\"' package.json"
 
 # Detect from config file
-"detect": "test -f your-framework.config.js"
+"command": "test -f your-framework.config.js"
 
-# Detect from directory
-"detect": "test -d src/your-framework"
+# Multiple conditions
+"command": "grep -q '\"dep\"' package.json || test -f config.js"
 ```
 
 ### SKILL.md Format
 
 Follow Anthropic best practices:
 - Keep main file < 500 lines
-- Use YAML frontmatter
-- Add table of contents
+- Use YAML frontmatter with rich description
 - Use progressive disclosure (link to resources/)
 - Include complete examples
 
 ```markdown
 ---
 name: your-framework
-displayName: Your Framework
-description: Complete description with all keywords for trigger matching (max 1024 chars)
-version: 1.0.0
+description: Complete description with keywords that help Claude activate this skill. Include framework name, key APIs, common tasks, and use cases. This is what Claude reads to decide when to load the skill.
 ---
 
 # Your Framework Development Guide
 
 Best practices for using Your Framework...
 
-## Table of Contents
+## Core Concepts
 
-- [Getting Started](#getting-started)
-- [Core Concepts](#core-concepts)
 ...
 
 ## Additional Resources
@@ -311,68 +354,37 @@ For detailed information, see:
 - [API Reference](resources/api-reference.md)
 ```
 
-### skill-rules-fragment.json Format
+**Key insight:** The `description` field is critical - Claude uses it to decide when to load your skill. Include all relevant keywords naturally in the description.
 
-```json
-{
-  "your-framework": {
-    "type": "domain",
-    "enforcement": "suggest",
-    "priority": "high",
-    "promptTriggers": {
-      "keywords": [
-        "your framework",
-        "framework name",
-        "key concepts"
-      ],
-      "intentPatterns": [
-        "create.*(component|route|feature)",
-        "add.*framework.*feature"
-      ]
-    },
-    "fileTriggers": {
-      "pathPatterns": [
-        "**/your-framework/**/*.ts",
-        "**/config.framework.js"
-      ],
-      "contentPatterns": [
-        "import.*from.*your-framework"
-      ]
-    }
-  }
-}
-```
+### Testing Your Plugin
 
-### Testing Your Kit
+1. **Test with plugin system:**
+   ```bash
+   # In Claude Code
+   /plugin install path/to/your-plugin
+   ```
 
-1. **Test detection:**
+2. **Test detection (for /setup):**
    ```bash
    cd test-project
-   bash cli/kits/your-framework/kit.json # run detect command
+   # Run the detect command from kit.json
+   grep -q '"your-framework"' package.json && echo "detected"
    ```
 
-2. **Test installation:**
-   ```bash
-   ./claude-setup
-   # Select your kit
-   # Verify files copied to .claude/
-   ```
+3. **Test skill activation:**
+   - Mention framework concepts in conversation
+   - Verify Claude loads and uses the skill
 
-3. **Test auto-activation:**
-   - Use trigger keywords in prompts
-   - Edit files matching pathPatterns
-   - Verify skill activates
-
-### Submitting Your Kit
+### Submitting Your Plugin
 
 1. Fork the repository
-2. Create your kit in `cli/kits/your-framework/`
-3. Test thoroughly
-4. Update this README's kit catalog
+2. Create your plugin in `cli/kits/your-framework/`
+3. Test with the plugin system
+4. Update this README's plugin catalog
 5. Submit pull request with:
-   - Kit name and description
+   - Plugin name and description
    - What it covers
-   - Detection mechanism
+   - Detection mechanism (for /setup)
    - Example usage
 
 ---
@@ -381,47 +393,49 @@ For detailed information, see:
 
 ```
 claude-code-kit/
+├── .claude-plugin/
+│   ├── plugin.json              # Main plugin metadata
+│   └── marketplace.json         # Marketplace registry
+├── commands/
+│   └── setup.md                 # /setup command for detection
 ├── cli/
-│   ├── core/                    # Always installed
+│   ├── core/                    # Core infrastructure (legacy installer)
 │   │   ├── hooks/              # 6 hooks
 │   │   ├── agents/             # 6 agents
 │   │   ├── commands/           # 6 commands
 │   │   └── skills/
-│   │       └── skill-developer/  # Meta-skill
-│   └── kits/                    # Framework-specific (optional)
+│   │       └── skill-developer/
+│   └── kits/                    # Framework plugins
 │       ├── nextjs/
+│       │   ├── .claude-plugin/plugin.json
+│       │   ├── kit.json        # Detection logic
+│       │   └── skills/
 │       ├── react/
-│       ├── shadcn/
-│       ├── tailwindcss/
-│       ├── mui/
-│       ├── tanstack-router/
-│       ├── tanstack-query/
 │       ├── express/
-│       ├── nodejs/
-│       └── prisma/
-├── claude-setup                 # Installation script
+│       ├── prisma/
+│       └── ... (10 plugins)
+├── claude-setup                 # Legacy installation script
 ├── package.json
 └── README.md
 ```
 
-**Template vs Installation:**
-- `cli/` directory = **Template** (what gets copied)
-- User's `.claude/` = **Installation** (what they get)
+**Two installation paths:**
+- **Plugin system:** `/plugin marketplace add` → `/plugin install`
+- **Legacy:** `npx github:blencorp/claude-code-kit` (copies to `.claude/`)
 
 ---
 
 ## Updates
 
-Re-run the installer to update or add kits:
+**Plugin system:** Plugins update automatically when you reinstall them:
+```bash
+/plugin install nextjs  # Reinstalls with latest version
+```
 
+**Legacy installer:** Re-run to update:
 ```bash
 npx github:blencorp/claude-code-kit
 ```
-
-The installer detects existing installations and offers:
-- Update existing kits to latest versions
-- Add new kits
-- Keep current setup
 
 ---
 
@@ -449,7 +463,7 @@ This project was inspired by [claude-code-infrastructure-showcase](https://githu
 
 ## Need Help?
 
-- **Installation issues:** Check detection commands in kit.json files
-- **Skills not activating:** Check `.claude/skills/skill-rules.json` was generated
-- **Framework not detected:** Create an issue or submit a kit!
-- **Contributing:** See [Contributing Kits](#contributing-kits) section above
+- **Plugin installation:** Make sure you've added the marketplace first with `/plugin marketplace add`
+- **Framework not detected by /setup:** Check the `detect.command` in the kit.json file
+- **Skill not activating:** Ensure the SKILL.md description includes relevant keywords
+- **Contributing:** See [Contributing Plugins](#contributing-plugins) section above

--- a/cli/core/skills/route-tester/SKILL.md
+++ b/cli/core/skills/route-tester/SKILL.md
@@ -1,6 +1,5 @@
 ---
 name: route-tester
-displayName: API Route Testing
 description: Framework-agnostic HTTP API route testing patterns, authentication strategies, and integration testing best practices. Supports REST APIs with JWT cookie authentication and other common auth patterns.
 ---
 

--- a/cli/kits/express/.claude-plugin/plugin.json
+++ b/cli/kits/express/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "express",
+  "description": "Express.js patterns including routing, middleware, controllers, error handling, request validation, authentication middleware, and RESTful API design.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  }
+}

--- a/cli/kits/express/.claude-plugin/plugin.json
+++ b/cli/kits/express/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "description": "Express.js patterns including routing, middleware, controllers, error handling, request validation, authentication middleware, and RESTful API design.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   }
 }

--- a/cli/kits/mui/.claude-plugin/plugin.json
+++ b/cli/kits/mui/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "mui",
+  "description": "Material-UI v7 component patterns including sx prop styling, theme customization, responsive design, and integration with React and TypeScript.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  }
+}

--- a/cli/kits/mui/.claude-plugin/plugin.json
+++ b/cli/kits/mui/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "description": "Material-UI v7 component patterns including sx prop styling, theme customization, responsive design, and integration with React and TypeScript.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   }
 }

--- a/cli/kits/nextjs/.claude-plugin/plugin.json
+++ b/cli/kits/nextjs/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "description": "Next.js 15+ App Router patterns including Server Components, Client Components, layouts, route handlers, server actions, data fetching, streaming, metadata, loading states, and error boundaries.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   }
 }

--- a/cli/kits/nextjs/.claude-plugin/plugin.json
+++ b/cli/kits/nextjs/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "nextjs",
+  "description": "Next.js 15+ App Router patterns including Server Components, Client Components, layouts, route handlers, server actions, data fetching, streaming, metadata, loading states, and error boundaries.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  }
+}

--- a/cli/kits/nextjs/skills/nextjs/SKILL.md
+++ b/cli/kits/nextjs/skills/nextjs/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: nextjs
-displayName: Next.js
 description: Next.js 15+ App Router development patterns including Server Components, Client Components, data fetching, layouts, and server actions. Use when creating pages, routes, layouts, components, API route handlers, server actions, loading states, error boundaries, or working with Next.js navigation and metadata.
-version: 1.0.0
 ---
 
 # Next.js Development Guidelines

--- a/cli/kits/nodejs/.claude-plugin/plugin.json
+++ b/cli/kits/nodejs/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "nodejs",
+  "description": "Node.js backend patterns with TypeScript including layered architecture (controllers, services, repositories), dependency injection, async patterns, streams, and error handling.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  }
+}

--- a/cli/kits/nodejs/.claude-plugin/plugin.json
+++ b/cli/kits/nodejs/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "description": "Node.js backend patterns with TypeScript including layered architecture (controllers, services, repositories), dependency injection, async patterns, streams, and error handling.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   }
 }

--- a/cli/kits/prisma/.claude-plugin/plugin.json
+++ b/cli/kits/prisma/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "prisma",
+  "description": "Prisma ORM patterns for type-safe database access including schema design, migrations, relations, queries, transactions, and integration with TypeScript.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  }
+}

--- a/cli/kits/prisma/.claude-plugin/plugin.json
+++ b/cli/kits/prisma/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "description": "Prisma ORM patterns for type-safe database access including schema design, migrations, relations, queries, transactions, and integration with TypeScript.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   }
 }

--- a/cli/kits/react/.claude-plugin/plugin.json
+++ b/cli/kits/react/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "description": "React 18+ patterns including hooks (useState, useEffect, useContext, useReducer, useMemo, useCallback), Suspense, lazy loading, error boundaries, and TypeScript integration.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   }
 }

--- a/cli/kits/react/.claude-plugin/plugin.json
+++ b/cli/kits/react/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "react",
+  "description": "React 18+ patterns including hooks (useState, useEffect, useContext, useReducer, useMemo, useCallback), Suspense, lazy loading, error boundaries, and TypeScript integration.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  }
+}

--- a/cli/kits/shadcn/.claude-plugin/plugin.json
+++ b/cli/kits/shadcn/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "description": "shadcn/ui component library patterns including Radix UI primitives, component customization, theming, accessibility, and integration with Tailwind CSS.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   }
 }

--- a/cli/kits/shadcn/.claude-plugin/plugin.json
+++ b/cli/kits/shadcn/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "shadcn",
+  "description": "shadcn/ui component library patterns including Radix UI primitives, component customization, theming, accessibility, and integration with Tailwind CSS.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  }
+}

--- a/cli/kits/shadcn/skills/shadcn/SKILL.md
+++ b/cli/kits/shadcn/skills/shadcn/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: shadcn
-displayName: shadcn/ui
 description: shadcn/ui component library patterns with Radix UI primitives and Tailwind CSS. Use when creating tables, forms, dialogs, cards, buttons, or any UI component using shadcn/ui, installing shadcn components, or styling with shadcn patterns.
-version: 1.0.0
 ---
 
 # shadcn/ui Development Guidelines

--- a/cli/kits/tailwindcss/.claude-plugin/plugin.json
+++ b/cli/kits/tailwindcss/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "description": "Tailwind CSS v4 utility-first patterns including responsive design, dark mode, custom themes, component extraction, and best practices for maintainable styles.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   }
 }

--- a/cli/kits/tailwindcss/.claude-plugin/plugin.json
+++ b/cli/kits/tailwindcss/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "tailwindcss",
+  "description": "Tailwind CSS v4 utility-first patterns including responsive design, dark mode, custom themes, component extraction, and best practices for maintainable styles.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  }
+}

--- a/cli/kits/tailwindcss/skills/tailwindcss/SKILL.md
+++ b/cli/kits/tailwindcss/skills/tailwindcss/SKILL.md
@@ -1,8 +1,6 @@
 ---
 name: tailwindcss
-displayName: Tailwind CSS
 description: Tailwind CSS v4 utility-first styling patterns including responsive design, dark mode, and custom configuration. Use when styling with Tailwind, adding utility classes, configuring Tailwind, setting up dark mode, or customizing the theme.
-version: 1.0.0
 ---
 
 # Tailwind CSS v4 Development Guidelines

--- a/cli/kits/tanstack-query/.claude-plugin/plugin.json
+++ b/cli/kits/tanstack-query/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "tanstack-query",
+  "description": "TanStack Query v5 data fetching patterns including useQuery, useMutation, useSuspenseQuery, query invalidation, optimistic updates, and infinite queries.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  }
+}

--- a/cli/kits/tanstack-query/.claude-plugin/plugin.json
+++ b/cli/kits/tanstack-query/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "description": "TanStack Query v5 data fetching patterns including useQuery, useMutation, useSuspenseQuery, query invalidation, optimistic updates, and infinite queries.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   }
 }

--- a/cli/kits/tanstack-router/.claude-plugin/plugin.json
+++ b/cli/kits/tanstack-router/.claude-plugin/plugin.json
@@ -3,6 +3,7 @@
   "description": "TanStack Router patterns including file-based routing, type-safe navigation, route loaders, search params, and integration with TanStack Query.",
   "version": "1.0.0",
   "author": {
-    "name": "blencorp"
+    "name": "blencorp",
+    "email": "support@blencorp.com"
   }
 }

--- a/cli/kits/tanstack-router/.claude-plugin/plugin.json
+++ b/cli/kits/tanstack-router/.claude-plugin/plugin.json
@@ -1,0 +1,8 @@
+{
+  "name": "tanstack-router",
+  "description": "TanStack Router patterns including file-based routing, type-safe navigation, route loaders, search params, and integration with TanStack Query.",
+  "version": "1.0.0",
+  "author": {
+    "name": "blencorp"
+  }
+}

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,0 +1,100 @@
+---
+description: Detect project frameworks and recommend plugins to install
+---
+
+# Project Setup - Framework Detection
+
+Analyze this project to detect which frameworks and libraries are in use, then recommend the appropriate Claude Code Kit plugins to install.
+
+## Detection Rules
+
+Run these checks to detect frameworks. For monorepos, check both root and workspace directories (apps/*, packages/*, services/*).
+
+### Frontend Frameworks
+
+**Next.js** - Check for:
+- `package.json` containing `"next"` dependency
+- `next.config.js` or `next.config.mjs` or `next.config.ts` file
+- `app/` directory with `layout.tsx` or `page.tsx`
+
+**React** - Check for:
+- `package.json` containing `"react"` dependency
+- `.tsx` or `.jsx` files with React imports
+
+**TailwindCSS** - Check for:
+- `package.json` containing `"tailwindcss"` dependency
+- `tailwind.config.js` or `tailwind.config.ts` file
+
+**shadcn/ui** - Check for:
+- `components.json` file (shadcn config)
+- `package.json` containing `"@radix-ui"` dependencies
+
+**Material-UI** - Check for:
+- `package.json` containing `"@mui/material"` dependency
+
+**TanStack Router** - Check for:
+- `package.json` containing `"@tanstack/react-router"` dependency
+
+**TanStack Query** - Check for:
+- `package.json` containing `"@tanstack/react-query"` dependency
+
+### Backend Frameworks
+
+**Express** - Check for:
+- `package.json` containing `"express"` dependency
+
+**Node.js** (general patterns) - Check for:
+- `package.json` exists
+- Server-side TypeScript/JavaScript files
+
+**Prisma** - Check for:
+- `package.json` containing `"prisma"` or `"@prisma/client"` dependency
+- `prisma/schema.prisma` file
+
+## Output Format
+
+After detection, output results in this format:
+
+```
+## Detected Frameworks
+
+✓ Next.js 15 (found in package.json)
+✓ React 18 (found in package.json)
+✓ TailwindCSS (found tailwind.config.ts)
+✓ Prisma (found prisma/schema.prisma)
+
+## Recommended Plugins
+
+To install these plugins from the claude-code-kit marketplace:
+
+1. First, add the marketplace (if not already added):
+   /plugin marketplace add blencorp/claude-code-kit
+
+2. Then install the detected plugins:
+   /plugin install nextjs react tailwindcss prisma
+
+## Available Plugins
+
+The claude-code-kit marketplace includes:
+
+| Plugin | Description |
+|--------|-------------|
+| nextjs | Next.js 15+ App Router patterns |
+| react | React 18+ hooks and component patterns |
+| express | Express.js routing and middleware |
+| nodejs | Node.js service layer patterns |
+| prisma | Prisma ORM and database patterns |
+| tailwindcss | Tailwind CSS v4 utility patterns |
+| shadcn | shadcn/ui component library |
+| mui | Material-UI v7 components |
+| tanstack-query | TanStack Query data fetching |
+| tanstack-router | TanStack Router file-based routing |
+```
+
+## Instructions
+
+1. Read the project's `package.json` file(s) to check dependencies
+2. Look for framework-specific config files
+3. For monorepos, check common workspace patterns (apps/*, packages/*)
+4. Output the detected frameworks and installation commands
+5. Be helpful - explain what each plugin provides

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -1,10 +1,10 @@
 ---
-description: Detect project frameworks and recommend plugins to install
+description: Detect project frameworks and install the appropriate plugins automatically
 ---
 
-# Project Setup - Framework Detection
+# Project Setup - Framework Detection & Installation
 
-Analyze this project to detect which frameworks and libraries are in use, then recommend the appropriate Claude Code Kit plugins to install.
+Analyze this project to detect which frameworks and libraries are in use, then **install the appropriate plugins automatically**.
 
 ## Detection Rules
 
@@ -12,89 +12,74 @@ Run these checks to detect frameworks. For monorepos, check both root and worksp
 
 ### Frontend Frameworks
 
-**Next.js** - Check for:
+**Next.js** (`nextjs` plugin) - Check for:
 - `package.json` containing `"next"` dependency
 - `next.config.js` or `next.config.mjs` or `next.config.ts` file
-- `app/` directory with `layout.tsx` or `page.tsx`
 
-**React** - Check for:
+**React** (`react` plugin) - Check for:
 - `package.json` containing `"react"` dependency
-- `.tsx` or `.jsx` files with React imports
 
-**TailwindCSS** - Check for:
+**TailwindCSS** (`tailwindcss` plugin) - Check for:
 - `package.json` containing `"tailwindcss"` dependency
 - `tailwind.config.js` or `tailwind.config.ts` file
 
-**shadcn/ui** - Check for:
+**shadcn/ui** (`shadcn` plugin) - Check for:
 - `components.json` file (shadcn config)
 - `package.json` containing `"@radix-ui"` dependencies
 
-**Material-UI** - Check for:
+**Material-UI** (`mui` plugin) - Check for:
 - `package.json` containing `"@mui/material"` dependency
 
-**TanStack Router** - Check for:
+**TanStack Router** (`tanstack-router` plugin) - Check for:
 - `package.json` containing `"@tanstack/react-router"` dependency
 
-**TanStack Query** - Check for:
+**TanStack Query** (`tanstack-query` plugin) - Check for:
 - `package.json` containing `"@tanstack/react-query"` dependency
 
 ### Backend Frameworks
 
-**Express** - Check for:
+**Express** (`express` plugin) - Check for:
 - `package.json` containing `"express"` dependency
 
-**Node.js** (general patterns) - Check for:
-- `package.json` exists
-- Server-side TypeScript/JavaScript files
+**Node.js** (`nodejs` plugin) - Check for:
+- `package.json` with `"type": "module"` and a backend framework
 
-**Prisma** - Check for:
+**Prisma** (`prisma` plugin) - Check for:
 - `package.json` containing `"prisma"` or `"@prisma/client"` dependency
 - `prisma/schema.prisma` file
-
-## Output Format
-
-After detection, output results in this format:
-
-```
-## Detected Frameworks
-
-✓ Next.js 15 (found in package.json)
-✓ React 18 (found in package.json)
-✓ TailwindCSS (found tailwind.config.ts)
-✓ Prisma (found prisma/schema.prisma)
-
-## Recommended Plugins
-
-To install these plugins from the claude-code-kit marketplace:
-
-1. First, add the marketplace (if not already added):
-   /plugin marketplace add blencorp/claude-code-kit
-
-2. Then install the detected plugins:
-   /plugin install nextjs react tailwindcss prisma
-
-## Available Plugins
-
-The claude-code-kit marketplace includes:
-
-| Plugin | Description |
-|--------|-------------|
-| nextjs | Next.js 15+ App Router patterns |
-| react | React 18+ hooks and component patterns |
-| express | Express.js routing and middleware |
-| nodejs | Node.js service layer patterns |
-| prisma | Prisma ORM and database patterns |
-| tailwindcss | Tailwind CSS v4 utility patterns |
-| shadcn | shadcn/ui component library |
-| mui | Material-UI v7 components |
-| tanstack-query | TanStack Query data fetching |
-| tanstack-router | TanStack Router file-based routing |
-```
 
 ## Instructions
 
 1. Read the project's `package.json` file(s) to check dependencies
 2. Look for framework-specific config files
-3. For monorepos, check common workspace patterns (apps/*, packages/*)
-4. Output the detected frameworks and installation commands
-5. Be helpful - explain what each plugin provides
+3. For monorepos, check common workspace patterns (apps/*, packages/*, services/*)
+4. Show the user what was detected
+5. **Install all detected plugins using `/plugin install <plugin-names>`**
+
+## Output Format
+
+After detection, show results and install:
+
+```
+## Detected Frameworks
+
+✓ Next.js (found "next" in package.json)
+✓ React (found "react" in package.json)
+✓ TailwindCSS (found tailwind.config.ts)
+✓ Prisma (found prisma/schema.prisma)
+
+## Installing Plugins
+
+Installing: nextjs, react, tailwindcss, prisma
+```
+
+Then run:
+```
+/plugin install nextjs react tailwindcss prisma
+```
+
+## Important
+
+- **Do the installation automatically** - don't just show recommendations
+- If no frameworks are detected, inform the user and list available plugins
+- For monorepos, detect across all workspaces and install all relevant plugins


### PR DESCRIPTION
This pull request introduces a new plugin-based marketplace system for Claude Code Kit, shifting from a legacy kit installer to a modern plugin architecture with automatic framework detection and installation. The documentation (`README.md`) has been extensively rewritten to reflect this new approach, clarify plugin structure, and provide guidance for both users and contributors. Additionally, plugin metadata files have been added for each supported framework, and marketplace registry files are now included.

**Plugin Marketplace System and Documentation Overhaul**

* Added `.claude-plugin/marketplace.json` to define the marketplace registry, listing all available plugins (Next.js, React, Express, Node.js, Prisma, TailwindCSS, shadcn, MUI, TanStack Query, TanStack Router) with descriptions and sources.
* Major rewrite of `README.md`:
  * Updated installation instructions for the new plugin system, clarified the difference between plugins and legacy kits, and provided detailed plugin structure and contribution guidelines. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R74) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R94) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R159) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L236-L304) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L314-R382) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R391-L425) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L452-R464)
  * Added sections on native skill activation, plugin detection, and testing, replacing legacy trigger-based activation with contextual loading based on skill descriptions. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R159) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L314-R382)
  * Updated troubleshooting and help sections to reflect plugin-based workflows.

**Plugin Metadata and Structure**

* Added `.claude-plugin/plugin.json` metadata files for each framework plugin (`nextjs`, `react`, `express`, `nodejs`, `prisma`, `mui`, `shadcn`), specifying name, description, version, and author. [[1]](diffhunk://#diff-5030d219dcd35c12690e8111371a3232face24e455e28737e961871c581d6cecR1-R9) [[2]](diffhunk://#diff-ce2d1a7adc4580ba36cda324702a0e87b067c110f2f855dfa1869683e1bf2e2cR1-R9) [[3]](diffhunk://#diff-a7ef7ee3a31ede63458969fb0d0f16e6d1b3d2ee1089a9b63d971bb7fcd69385R1-R9) [[4]](diffhunk://#diff-63364751446d662305c3dc55a96ffbf07b041200fd422863adbb2d55f3aee175R1-R9) [[5]](diffhunk://#diff-0d1d4ea5f1bdcbe5527e7d005b8919c567bd66c520851b1eb72be3ea41c1f6a6R1-R9) [[6]](diffhunk://#diff-1e61c9adb839bc9849b3fdcb737a84c091ad198769c5e098f77ddb450a0c56e6R1-R9) [[7]](diffhunk://#diff-76f5871f7e09e0166c8e6f5f338858e2d5e7bd4410494358facef17a00355ee6R1-R9)
* Introduced `.claude-plugin/plugin.json` for the main marketplace plugin, including repository and author info.

**Skill Metadata Updates**

* Removed unnecessary `displayName` and `version` fields from skill YAML frontmatter in `SKILL.md` files to streamline metadata and align with plugin-based activation. [[1]](diffhunk://#diff-69e854607daf3cc2f3d8ccba7bb1a470cdcb7ca12047a0c47f8b9344efc3b384L3) [[2]](diffhunk://#diff-3852a7f255e24438faadb130426eec5c687bda67667ab7688ff5a6e49167efacL3-L5)

(References: [[1]](diffhunk://#diff-5352ee4067f17e7948e1425843f0a454e045bc8edf338f0bcf75c6804ddabd9aR1-R82) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R74) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L54-R94) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L112-R159) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L236-L304) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L314-R382) [[7]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R391-L425) [[8]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L452-R464) [[9]](diffhunk://#diff-5030d219dcd35c12690e8111371a3232face24e455e28737e961871c581d6cecR1-R9) [[10]](diffhunk://#diff-ce2d1a7adc4580ba36cda324702a0e87b067c110f2f855dfa1869683e1bf2e2cR1-R9) [[11]](diffhunk://#diff-a7ef7ee3a31ede63458969fb0d0f16e6d1b3d2ee1089a9b63d971bb7fcd69385R1-R9) [[12]](diffhunk://#diff-63364751446d662305c3dc55a96ffbf07b041200fd422863adbb2d55f3aee175R1-R9) [[13]](diffhunk://#diff-0d1d4ea5f1bdcbe5527e7d005b8919c567bd66c520851b1eb72be3ea41c1f6a6R1-R9) [[14]](diffhunk://#diff-1e61c9adb839bc9849b3fdcb737a84c091ad198769c5e098f77ddb450a0c56e6R1-R9) [[15]](diffhunk://#diff-76f5871f7e09e0166c8e6f5f338858e2d5e7bd4410494358facef17a00355ee6R1-R9) [[16]](diffhunk://#diff-037fda53525563fb89230704794a06db1150204ca28ce80697a637121c3ed3f9R1-R10) [[17]](diffhunk://#diff-69e854607daf3cc2f3d8ccba7bb1a470cdcb7ca12047a0c47f8b9344efc3b384L3) [[18]](diffhunk://#diff-3852a7f255e24438faadb130426eec5c687bda67667ab7688ff5a6e49167efacL3-L5)